### PR TITLE
See Issue  #5. Fix is very simple

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -27,6 +27,7 @@ grails.project.dependency.resolution = {
         build(":release:1.0.0.M3", ":svn:latest.integration") {
             export = false
         }
+        runtime ':quartz:0.4.2'
         compile ':quartz:0.4.2'
     }
     dependencies {


### PR DESCRIPTION
Have the plugin compatible with grails 1.3.3 or lower (see http://jira.grails.org/browse/GRAILS-6503 for details) by implementing a workaround
