### PR TITLE
Cater for jobs that does not use hibernate session

### DIFF
--- a/src/java/org/grails/plugins/quartz/QuartzMonitorJobFactory.java
+++ b/src/java/org/grails/plugins/quartz/QuartzMonitorJobFactory.java
@@ -62,7 +62,9 @@ public class QuartzMonitorJobFactory extends GrailsJobFactory {
             long start = System.currentTimeMillis();
             try {
                 job.execute(context);
-                sessionFactory.getCurrentSession().flush();
+                if (job.job.sessionRequired) {
+                    sessionFactory.getCurrentSession().flush();
+                }
             } catch (Throwable e) {
                 jobDetails.put("error", e.getMessage());
                 jobDetails.put("status", "error");


### PR DESCRIPTION
I get the following exception when my job, which does not use hibernate session, runs.

Exception occured in job: GRAILS_JOBS.dsync.client.WtfJob (org.codehaus.groovy.grails.plugins.quartz.listeners.ExceptionPrinterJobListener)
org.quartz.JobExecutionException: No Hibernate Session bound to thread, and configuration does not allow creation of non-transactional one here [See nested exception: org.hibernate.HibernateException: No Hibernate Session bound to thread, and configuration does not allow creation of non-transactional one here]

Cheers,
Andy
