### PR TITLE
Fixed concurrency issue in QuartzMonitorJobFactory

### DIFF
--- a/src/java/org/grails/plugins/quartz/QuartzMonitorJobFactory.java
+++ b/src/java/org/grails/plugins/quartz/QuartzMonitorJobFactory.java
@@ -3,7 +3,7 @@ package org.grails.plugins.quartz;
 import grails.plugins.quartz.GrailsJobFactory;
 
 import java.util.Date;
-import java.util.HashMap;
+import java.util.ConcurrentHashMap;
 import java.util.Map;
 
 import org.hibernate.SessionFactory;
@@ -19,7 +19,7 @@ import org.quartz.spi.TriggerFiredBundle;
  * @since 0.1
  */
 public class QuartzMonitorJobFactory extends GrailsJobFactory {
-    static final java.util.Map<String, Map<String, Object>> jobRuns = new HashMap<String, Map<String, Object>>();
+    static final java.util.Map<String, Map<String, Object>> jobRuns = new ConcurrentHashMap<String, Map<String, Object>>();
     private SessionFactory sessionFactory;
 
     public void setSessionFactory(SessionFactory sessionFactory) {
@@ -34,7 +34,7 @@ public class QuartzMonitorJobFactory extends GrailsJobFactory {
             if (jobRuns.containsKey(uniqueTriggerName)) {
                 map = jobRuns.get(uniqueTriggerName);
             } else {
-                map = new HashMap<String, Object>();
+                map = new ConcurrentHashMap<String, Object>();
                 jobRuns.put(uniqueTriggerName, map);
             }
             job = new QuartzDisplayJob((GrailsJob) job, map, sessionFactory);


### PR DESCRIPTION
Changed HashMap to ConcurrentHashMap, as HashMaps are not thread-safe. However the maps are potentially modified and read concurrently.
