### PR TITLE
#40 - do not flush anymore as that is handled by quartz plugin

### DIFF
--- a/src/main/groovy/grails/plugins/quartz/QuartzDisplayJob.groovy
+++ b/src/main/groovy/grails/plugins/quartz/QuartzDisplayJob.groovy
@@ -1,6 +1,5 @@
 package grails.plugins.quartz
 
-import grails.plugins.GrailsVersionUtils
 import org.quartz.Job
 import org.quartz.JobExecutionContext
 import org.quartz.JobExecutionException
@@ -11,14 +10,10 @@ import org.quartz.JobExecutionException
 class QuartzDisplayJob implements Job {
     GrailsJobFactory.GrailsJob job
     Map<String, Object> jobDetails
-    private sessionFactory
-    private pluginManager
 
-    QuartzDisplayJob(GrailsJobFactory.GrailsJob job, Map<String, Object> jobDetails, sessionFactory, pluginManager) {
+    QuartzDisplayJob(GrailsJobFactory.GrailsJob job, Map<String, Object> jobDetails) {
         this.job = job
         this.jobDetails = jobDetails
-        this.sessionFactory = sessionFactory
-        this.pluginManager = pluginManager
     }
 
     void execute(final JobExecutionContext context) throws JobExecutionException {
@@ -32,7 +27,6 @@ class QuartzDisplayJob implements Job {
         long start = System.currentTimeMillis()
         try {
             job.execute(context)
-            flushSession(jobJob)
             jobDetails.status = "complete"
         } catch (Throwable e) {
             jobDetails.error = e.class.simpleName + ' : ' + e.message
@@ -50,17 +44,4 @@ class QuartzDisplayJob implements Job {
         thing.metaClass.hasProperty(thing, name)
     }
 
-    private void flushSession(job) {
-        if (hasProperty(job, 'sessionRequired') && !job.sessionRequired) {
-            return
-        }
-
-        if (sessionFactory && pluginManager) {
-            if (pluginManager.getGrailsPlugin('hibernate4') || GrailsVersionUtils.isVersionGreaterThan("4.0.0", pluginManager.getGrailsPlugin('hibernate').version)) {
-                sessionFactory.currentSession?.flush()
-            } else { // must be hibernate 3 - too much of an assumption??
-                org.springframework.orm.hibernate3.SessionFactoryUtils.getSession(sessionFactory, false)?.flush()
-            }
-        }
-    }
 }

--- a/src/main/groovy/grails/plugins/quartz/QuartzMonitorJobFactory.groovy
+++ b/src/main/groovy/grails/plugins/quartz/QuartzMonitorJobFactory.groovy
@@ -15,9 +15,6 @@ class QuartzMonitorJobFactory extends GrailsJobFactory {
 
     static final ConcurrentMap<String, Map<String, Object>> jobRuns = new ConcurrentHashMap<String, Map<String, Object>>()
 
-    def sessionFactory
-    def pluginManager
-
     @Override
     protected createJobInstance(TriggerFiredBundle bundle) {
         String uniqueTriggerName = bundle.trigger.key.name
@@ -31,6 +28,6 @@ class QuartzMonitorJobFactory extends GrailsJobFactory {
             jobRuns[uniqueTriggerName] = map = new ConcurrentHashMap<String, Object>()
         }
 
-        return new QuartzDisplayJob((GrailsJobFactory.GrailsJob) job, map, sessionFactory, pluginManager)
+        return new QuartzDisplayJob((GrailsJobFactory.GrailsJob) job, map)
     }
 }

--- a/src/main/groovy/grails/plugins/quartzmonitor/QuartzMonitorGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugins/quartzmonitor/QuartzMonitorGrailsPlugin.groovy
@@ -19,11 +19,6 @@ class QuartzMonitorGrailsPlugin {
     def loadAfter = ['quartz']
 
     def doWithSpring = {
-        quartzJobFactory(QuartzMonitorJobFactory) {
-            if (manager?.hasGrailsPlugin("hibernate") || manager?.hasGrailsPlugin("hibernate4")) {
-                sessionFactory = ref("sessionFactory")
-            }
-            pluginManager = ref("pluginManager")
-        }
+        quartzJobFactory(QuartzMonitorJobFactory)
     }
 }


### PR DESCRIPTION
would be great if this gets released as 1.3.1 or 1.4.0. thank you!

i tested locally published to maven local as 1.3.1.BUILD-SNAPSHOT with an app that uses hibernate-5.2 and threw an exception before (on flush by `QuartzDisplayJob`). no more exception after the change.