### PR TITLE
Removes replacing job.name with job.description (Issue #36)

### DIFF
--- a/src/main/groovy/grails/plugins/quartz/QuartzDisplayJob.groovy
+++ b/src/main/groovy/grails/plugins/quartz/QuartzDisplayJob.groovy
@@ -24,9 +24,7 @@ class QuartzDisplayJob implements Job {
     void execute(final JobExecutionContext context) throws JobExecutionException {
         jobDetails.clear()
         def jobJob = job.job
-        if (hasProperty(jobJob, 'description') && jobJob.description) {
-            jobDetails.name = jobJob.description
-        }
+
         jobDetails.lastRun = new Date()
         jobDetails.status = "running"
         long start = System.currentTimeMillis()


### PR DESCRIPTION
I'm not sure what was getting fixed / added with replacing the `job.name` with `job.description`. But as issue #36 describes, it breaks the buttons making the list view in operable once you start interacting with the jobs.

I would be willing to put more work into this area to restore the intended functionality and not break the UI if you are willing to share it.